### PR TITLE
Add table schema support to GetTables

### DIFF
--- a/docs/flightsql-manifest.md
+++ b/docs/flightsql-manifest.md
@@ -3,7 +3,7 @@
 ## Metadata RPCs
 - [x] GetCatalogs
 - [x] GetSchemas
-- [~] GetTables
+ - [x] GetTables
 - [x] GetTableTypes
 - [ ] GetColumns
 - [x] GetPrimaryKeys

--- a/pkg/repositories/interfaces.go
+++ b/pkg/repositories/interfaces.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/apache/arrow-go/v18/arrow"
+
 	"github.com/TFMV/hatch/pkg/models"
 )
 
@@ -44,6 +46,8 @@ type MetadataRepository interface {
 	GetTableTypes(ctx context.Context) ([]string, error)
 	// GetColumns returns columns for a specific table.
 	GetColumns(ctx context.Context, table models.TableRef) ([]models.Column, error)
+	// GetTableSchema returns the Arrow schema for a table.
+	GetTableSchema(ctx context.Context, table models.TableRef) (*arrow.Schema, error)
 	// GetPrimaryKeys returns primary keys for a table.
 	GetPrimaryKeys(ctx context.Context, table models.TableRef) ([]models.Key, error)
 	// GetImportedKeys returns foreign keys that reference a table.

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+
 	"github.com/TFMV/hatch/pkg/models"
 	"github.com/TFMV/hatch/pkg/repositories"
 )
@@ -26,6 +28,7 @@ type MetadataService interface {
 	GetTables(ctx context.Context, opts models.GetTablesOptions) ([]models.Table, error)
 	GetTableTypes(ctx context.Context) ([]string, error)
 	GetColumns(ctx context.Context, table models.TableRef) ([]models.Column, error)
+	GetTableSchema(ctx context.Context, table models.TableRef) (*arrow.Schema, error)
 	GetPrimaryKeys(ctx context.Context, table models.TableRef) ([]models.Key, error)
 	GetImportedKeys(ctx context.Context, table models.TableRef) ([]models.ForeignKey, error)
 	GetExportedKeys(ctx context.Context, table models.TableRef) ([]models.ForeignKey, error)


### PR DESCRIPTION
## Summary
- implement `GetTableSchema` in metadata layer for DuckDB
- expose new method through services
- use table schema in metadata handler when requested
- update Flight SQL manifest

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685278d3b814832eb00bc467c519ca7e