### PR TITLE
Fix GetColumns build error and update manifest

### DIFF
--- a/docs/flightsql-manifest.md
+++ b/docs/flightsql-manifest.md
@@ -9,7 +9,7 @@
 - [x] GetPrimaryKeys
 - [x] GetImportedKeys
 - [x] GetExportedKeys
-- [ ] GetCrossReference
+- [~] GetCrossReference
 
 ## Execution RPCs
 - [x] DoGet

--- a/pkg/server/flight_sql.go
+++ b/pkg/server/flight_sql.go
@@ -349,8 +349,8 @@ func (s *FlightSQLServer) DoGetTableTypes(
 }
 
 func (s *FlightSQLServer) GetFlightInfoColumns(
-        ctx context.Context,
-        cmd flightsql.CommandGetColumns,
+	ctx context.Context,
+	cmd flightsql.GetColumns,
 	desc *flight.FlightDescriptor,
 ) (*flight.FlightInfo, error) {
 	return s.infoFromHandler(ctx, desc, func() (*arrow.Schema, <-chan flight.StreamChunk, error) {
@@ -365,8 +365,8 @@ func (s *FlightSQLServer) GetFlightInfoColumns(
 }
 
 func (s *FlightSQLServer) DoGetColumns(
-        ctx context.Context,
-        cmd flightsql.CommandGetColumns,
+	ctx context.Context,
+	cmd flightsql.GetColumns,
 ) (*arrow.Schema, <-chan flight.StreamChunk, error) {
 	return s.metadataHandler.GetColumns(
 		ctx,


### PR DESCRIPTION
## Summary
- fix Build by using `flightsql.GetColumns`
- mark GetCrossReference metadata call as partially implemented

## Testing
- `gofmt -w pkg/server/flight_sql.go docs/flightsql-manifest.md`

------
https://chatgpt.com/codex/tasks/task_e_6852804c95f8832e89377f970c66047b