### PR TITLE
Fix column command type and update manifest

### DIFF
--- a/docs/flightsql-manifest.md
+++ b/docs/flightsql-manifest.md
@@ -9,7 +9,7 @@
 - [x] GetPrimaryKeys
 - [x] GetImportedKeys
 - [x] GetExportedKeys
-- [~] GetCrossReference
+- [x] GetCrossReference
 
 ## Execution RPCs
 - [x] DoGet

--- a/pkg/server/flight_sql.go
+++ b/pkg/server/flight_sql.go
@@ -350,7 +350,7 @@ func (s *FlightSQLServer) DoGetTableTypes(
 
 func (s *FlightSQLServer) GetFlightInfoColumns(
 	ctx context.Context,
-	cmd flightsql.CommandGetColumns,
+	cmd flightsql.GetColumns,
 	desc *flight.FlightDescriptor,
 ) (*flight.FlightInfo, error) {
 	return s.infoFromHandler(ctx, desc, func() (*arrow.Schema, <-chan flight.StreamChunk, error) {
@@ -366,7 +366,7 @@ func (s *FlightSQLServer) GetFlightInfoColumns(
 
 func (s *FlightSQLServer) DoGetColumns(
 	ctx context.Context,
-	cmd flightsql.CommandGetColumns,
+	cmd flightsql.GetColumns,
 ) (*arrow.Schema, <-chan flight.StreamChunk, error) {
 	return s.metadataHandler.GetColumns(
 		ctx,


### PR DESCRIPTION
## Summary
- fix method signatures to use `flightsql.GetColumns`
- mark `GetCrossReference` as fully implemented in the manifest

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24)*
- `go test ./...` *(fails: go.mod requires go >= 1.24)*
- `go build ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_685282f0e6cc832e911972d2ac899d8a