### PR TITLE
Fix GetColumns type usage

### DIFF
--- a/pkg/server/flight_sql.go
+++ b/pkg/server/flight_sql.go
@@ -350,7 +350,7 @@ func (s *FlightSQLServer) DoGetTableTypes(
 
 func (s *FlightSQLServer) GetFlightInfoColumns(
 	ctx context.Context,
-	cmd flightsql.GetColumns,
+	cmd flightsql.CommandGetColumns,
 	desc *flight.FlightDescriptor,
 ) (*flight.FlightInfo, error) {
 	return s.infoFromHandler(ctx, desc, func() (*arrow.Schema, <-chan flight.StreamChunk, error) {
@@ -366,7 +366,7 @@ func (s *FlightSQLServer) GetFlightInfoColumns(
 
 func (s *FlightSQLServer) DoGetColumns(
 	ctx context.Context,
-	cmd flightsql.GetColumns,
+	cmd flightsql.CommandGetColumns,
 ) (*arrow.Schema, <-chan flight.StreamChunk, error) {
 	return s.metadataHandler.GetColumns(
 		ctx,


### PR DESCRIPTION
## Summary
- update `GetFlightInfoColumns` and `DoGetColumns` to use `flightsql.CommandGetColumns`

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_6852882c7214832e9df472f185419b02