### PR TITLE
Fix flightsql type mismatch

### DIFF
--- a/pkg/server/flight_sql.go
+++ b/pkg/server/flight_sql.go
@@ -350,7 +350,7 @@ func (s *FlightSQLServer) DoGetTableTypes(
 
 func (s *FlightSQLServer) GetFlightInfoColumns(
 	ctx context.Context,
-	cmd flightsql.CommandGetColumns,
+	cmd flightsql.GetColumns,
 	desc *flight.FlightDescriptor,
 ) (*flight.FlightInfo, error) {
 	return s.infoFromHandler(ctx, desc, func() (*arrow.Schema, <-chan flight.StreamChunk, error) {
@@ -366,7 +366,7 @@ func (s *FlightSQLServer) GetFlightInfoColumns(
 
 func (s *FlightSQLServer) DoGetColumns(
 	ctx context.Context,
-	cmd flightsql.CommandGetColumns,
+	cmd flightsql.GetColumns,
 ) (*arrow.Schema, <-chan flight.StreamChunk, error) {
 	return s.metadataHandler.GetColumns(
 		ctx,


### PR DESCRIPTION
## Summary
- update FlightSQL server to use flightsql.GetColumns type

## Testing
- `go build ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_6852890c56f4832ea52ad90e7e3816fe