### PR TITLE
Improve validation for Flight RPCs

### DIFF
--- a/pkg/services/prepared_statement_service.go
+++ b/pkg/services/prepared_statement_service.go
@@ -375,6 +375,13 @@ func (s *preparedStatementService) SetParameters(ctx context.Context, handle str
 		return err // Get already logs and increments metrics
 	}
 
+	if stmt.ParameterSchema != nil && len(params) > 0 {
+		expected := len(stmt.ParameterSchema.Fields())
+		if len(params[0]) != expected {
+			return errors.New(errors.CodeInvalidRequest, fmt.Sprintf("parameter count mismatch: expected %d got %d", expected, len(params[0])))
+		}
+	}
+
 	// Store parameters in the statement model (or call repository to update if needed)
 	// This depends on how the repository and model are designed to handle parameter binding.
 	// For this example, let's assume the PreparedStatement model can hold the bound parameters.

--- a/pkg/services/query_service.go
+++ b/pkg/services/query_service.go
@@ -207,8 +207,10 @@ func (s *queryService) ValidateQuery(ctx context.Context, query string) error {
 		}
 	}
 
-	// TODO: For now, we consider the query valid if it's not empty
-	// In the future, we could use EXPLAIN to validate without execution
+	if err := s.classifier.ValidateStatement(query); err != nil {
+		return errors.New(errors.CodeInvalidRequest, err.Error())
+	}
+
 	return nil
 }
 
@@ -243,6 +245,10 @@ func (s *queryService) validateUpdateRequest(req *models.UpdateRequest) error {
 
 	if req.Statement == "" {
 		return errors.New(errors.CodeInvalidRequest, "statement cannot be empty")
+	}
+
+	if err := s.classifier.ValidateStatement(req.Statement); err != nil {
+		return errors.New(errors.CodeInvalidRequest, err.Error())
 	}
 
 	// Validate timeout


### PR DESCRIPTION
## Summary
- validate descriptor and SQL in CreatePreparedStatement
- guard HandleDoPut against nil inputs and missing schema
- verify parameter counts when setting prepared statement parameters
- parse-check queries and updates via statement classifier
- handle nil descriptors for metadata helpers

## Testing
- `go test ./...` *(fails: forbidden access to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6852a100196c832e86ccd1bc8716b7b8