### PR TITLE
Finalize Flight SQL docs

### DIFF
--- a/docs/flightsql-manifest.md
+++ b/docs/flightsql-manifest.md
@@ -3,7 +3,7 @@
 ## Metadata RPCs
 - [x] GetCatalogs
 - [x] GetSchemas
- - [x] GetTables
+- [x] GetTables
 - [x] GetTableTypes
 - [x] GetColumns
 - [x] GetPrimaryKeys
@@ -14,7 +14,7 @@
 ## Execution RPCs
 - [x] DoGet
 - [x] DoPut
- - [~] DoExchange
+- [~] DoExchange
 - [x] CreatePreparedStatement
 - [x] ClosePreparedStatement
 
@@ -38,3 +38,13 @@
 - [x] GetSQLInfo
 - [x] CreatePreparedStatement
 - [x] ClosePreparedStatement
+
+## Known Limitations
+- [ ] DoExchange not supported
+- [ ] No TLS support
+- [ ] Authentication is experimental
+
+## Next Roadmap Items
+- Implement DoExchange
+- Add authentication plugins
+- Expand SQLInfo catalogue


### PR DESCRIPTION
## Summary
- document Hatch architecture and usage
- polish instructions for connecting via Flight SQL and JDBC
- update feature manifest with known limitations and roadmap

## Testing
- `make test` *(fails: fetching modules disallowed)*

------
https://chatgpt.com/codex/tasks/task_e_6852a448475c832e9f8b12ca49224e74