### PR TITLE
Add client roundtrip integration tests

### DIFF
--- a/test/integration/FlightSqlJavaIT.java
+++ b/test/integration/FlightSqlJavaIT.java
@@ -1,0 +1,34 @@
+import org.apache.arrow.flight.*;
+import org.apache.arrow.flight.sql.*;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+public class FlightSqlJavaIT {
+    public static void main(String[] args) throws Exception {
+        RootAllocator allocator = new RootAllocator();
+        try (FlightClient client = FlightClient.builder()
+                .allocator(allocator)
+                .location(Location.forGrpcInsecure("localhost", 32010))
+                .build();
+             FlightSqlClient sqlClient = new FlightSqlClient(client)) {
+
+            sqlClient.executeUpdate("CREATE TABLE java_roundtrip(id INTEGER)");
+            sqlClient.executeUpdate("INSERT INTO java_roundtrip VALUES (42)");
+
+            try (FlightSqlClient.PreparedStatement stmt =
+                         sqlClient.prepare("SELECT id FROM java_roundtrip WHERE id = ?")) {
+                stmt.setBigInt(1, 42);
+                FlightInfo info = stmt.executeQuery();
+                try (FlightStream stream = sqlClient.getStream(info.getEndpoints().get(0).getTicket())) {
+                    VectorSchemaRoot root = stream.getRoot();
+                    while (stream.next()) {
+                        int v = root.getVector(0).getInt(0);
+                        if (v != 42) {
+                            throw new IllegalStateException("Unexpected value: " + v);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/integration/test_pyflightsql.py
+++ b/test/integration/test_pyflightsql.py
@@ -1,0 +1,67 @@
+import subprocess
+import time
+import os
+import duckdb
+
+try:
+    from pyarrow import flight
+    from pyarrow.flight import sql as flightsql
+    import pyarrow as pa
+except ImportError as e:
+    raise SystemExit(f"pyarrow not installed: {e}")
+
+
+def start_server():
+    env = os.environ.copy()
+    proc = subprocess.Popen(
+        ["go", "run", "./cmd/server", "serve", "--address", "localhost:32010", "--database", ":memory:", "--log-level", "error"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    time.sleep(2)
+    return proc
+
+
+def stop_server(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def roundtrip_query(client, query, params=None):
+    if params is None:
+        info = client.execute(query)
+    else:
+        prepared = client.prepare(query)
+        prepared.execute_update(params)
+        info = prepared.execute()
+        prepared.close()
+    return client._client.get_stream(info.endpoints[0].ticket).read_all()
+
+
+def test_cross_client_roundtrip():
+    proc = start_server()
+    try:
+        client = flightsql.FlightSqlClient("grpc://localhost:32010")
+        client._client.wait_for_ready(timeout=5)
+        client.execute_update("CREATE TABLE py_test(id INTEGER, name TEXT)")
+        data = pa.Table.from_pydict({"id": [1], "name": ["flight"]})
+        prep = client.prepare("INSERT INTO py_test VALUES (?, ?)")
+        prep.execute_update(data)
+        prep.close()
+        table = roundtrip_query(client, "SELECT * FROM py_test")
+        expected = duckdb.sql("SELECT 1 AS id, 'flight' AS name").arrow()
+        assert table.equals(expected)
+
+        # metadata roundtrips
+        meta_tables = client.get_tables().read_all()
+        meta_cols = client.get_columns(None, None, "py_test", None).read_all()
+        sql_info = client.get_sql_info([flightsql.SqlInfo.FLIGHT_SQL_SERVER_NAME])
+        assert meta_tables.num_rows >= 1
+        assert meta_cols.num_rows == 1
+        assert len(sql_info[0]) > 0
+    finally:
+        stop_server(proc)


### PR DESCRIPTION
## Summary
- add Python and Java Flight SQL integration tests demonstrating cross-client usage

## Testing
- `go test ./...` *(fails: could not fetch Go toolchain)*
- `python3 test/integration/test_pyflightsql.py` *(fails: ModuleNotFoundError: No module named 'duckdb')*
- `javac test/integration/FlightSqlJavaIT.java` *(fails: cannot find symbol errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852d2ddf168832eb8d26c32fb95f3c7