### PR TITLE
Add fuzz tests for Flight SQL

### DIFF
--- a/pkg/server/flight_sql_fuzz_test.go
+++ b/pkg/server/flight_sql_fuzz_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// FuzzFlightSQLServer exercises FlightSQL server methods with random inputs to
+// ensure robustness against malformed requests.
+func FuzzFlightSQLServer(f *testing.F) {
+	f.Add([]byte("SELECT 1"))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		server, _, metadataHandler, _, psHandler := setupTestServer(t)
+		allocator := memory.NewGoAllocator()
+
+		// safe defaults for handlers
+		metadataHandler.getSqlInfoFunc = func(ctx context.Context, info []uint32) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+			schema := arrow.NewSchema([]arrow.Field{{Name: "k", Type: arrow.PrimitiveTypes.Int32}}, nil)
+			ch := make(chan flight.StreamChunk)
+			close(ch)
+			return schema, ch, nil
+		}
+		metadataHandler.getXdbcTypeInfoFunc = func(ctx context.Context, dt *int32) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+			schema := arrow.NewSchema([]arrow.Field{{Name: "k", Type: arrow.PrimitiveTypes.Int32}}, nil)
+			ch := make(chan flight.StreamChunk)
+			close(ch)
+			return schema, ch, nil
+		}
+
+		psHandler.createFunc = func(ctx context.Context, q string, tx string) (string, *arrow.Schema, error) {
+			return "h", arrow.NewSchema(nil, nil), nil
+		}
+		psHandler.closeFunc = func(ctx context.Context, h string) error { return nil }
+		psHandler.getSchemaFunc = func(ctx context.Context, h string) (*arrow.Schema, error) {
+			return arrow.NewSchema([]arrow.Field{{Name: "v", Type: arrow.PrimitiveTypes.Int64}}, nil), nil
+		}
+		psHandler.setParametersFunc = func(ctx context.Context, h string, p arrow.Record) error { return nil }
+		psHandler.executeUpdateFunc = func(ctx context.Context, h string, p arrow.Record) (int64, error) { return 0, nil }
+
+		ctx := context.Background()
+		query := string(data)
+
+		server.GetFlightInfoStatement(ctx, &statementQuery{query: query}, &flight.FlightDescriptor{Type: flight.DescriptorCMD, Cmd: data})
+		server.DoGetStatement(ctx, &statementQueryTicket{handle: data})
+
+		schema1 := arrow.NewSchema([]arrow.Field{{Name: "v", Type: arrow.PrimitiveTypes.Int64}}, nil)
+		b1 := array.NewRecordBuilder(allocator, schema1)
+		b1.Field(0).(*array.Int64Builder).Append(1)
+		rec1 := b1.NewRecord()
+		b1.Release()
+
+		schema2 := arrow.NewSchema([]arrow.Field{{Name: "v", Type: arrow.PrimitiveTypes.Float64}}, nil)
+		b2 := array.NewRecordBuilder(allocator, schema2)
+		b2.Field(0).(*array.Float64Builder).Append(1.0)
+		rec2 := b2.NewRecord()
+		b2.Release()
+
+		reader := &sliceMessageReader{records: []arrow.Record{rec1, rec2}}
+		writer := nopMetadataWriter{}
+		server.DoPutPreparedStatementQuery(ctx, &preparedStatementQueryCmd{handle: data}, reader, writer)
+
+		reader = &sliceMessageReader{records: []arrow.Record{rec1}}
+		server.DoPutPreparedStatementUpdate(ctx, &preparedStatementUpdateCmd{handle: data}, reader)
+
+		server.GetFlightInfoSqlInfo(ctx, &flightsql.GetSqlInfo{Info: []uint32{99999}}, &flight.FlightDescriptor{Type: flight.DescriptorCMD, Cmd: data})
+
+		rec1.Release()
+		rec2.Release()
+	})
+}

--- a/pkg/server/flight_sql_test.go
+++ b/pkg/server/flight_sql_test.go
@@ -42,12 +42,14 @@ func (m *mockQueryHandler) ExecuteUpdate(ctx context.Context, query string, txnI
 
 type mockMetadataHandler struct {
 	handlers.MetadataHandler
-	getCatalogsFunc    func(ctx context.Context) (*arrow.Schema, <-chan flight.StreamChunk, error)
-	getSchemasFunc     func(ctx context.Context, catalog *string, schemaPattern *string) (*arrow.Schema, <-chan flight.StreamChunk, error)
-	getTablesFunc      func(ctx context.Context, catalog *string, schemaPattern *string, tablePattern *string, tableTypes []string, includeSchema bool) (*arrow.Schema, <-chan flight.StreamChunk, error)
-	getColumnsFunc     func(ctx context.Context, catalog *string, schemaPattern *string, tablePattern *string, columnPattern *string) (*arrow.Schema, <-chan flight.StreamChunk, error)
-	getTableTypesFunc  func(ctx context.Context) (*arrow.Schema, <-chan flight.StreamChunk, error)
-	getPrimaryKeysFunc func(ctx context.Context, catalog *string, schema *string, table string) (*arrow.Schema, <-chan flight.StreamChunk, error)
+	getCatalogsFunc     func(ctx context.Context) (*arrow.Schema, <-chan flight.StreamChunk, error)
+	getSchemasFunc      func(ctx context.Context, catalog *string, schemaPattern *string) (*arrow.Schema, <-chan flight.StreamChunk, error)
+	getTablesFunc       func(ctx context.Context, catalog *string, schemaPattern *string, tablePattern *string, tableTypes []string, includeSchema bool) (*arrow.Schema, <-chan flight.StreamChunk, error)
+	getColumnsFunc      func(ctx context.Context, catalog *string, schemaPattern *string, tablePattern *string, columnPattern *string) (*arrow.Schema, <-chan flight.StreamChunk, error)
+	getTableTypesFunc   func(ctx context.Context) (*arrow.Schema, <-chan flight.StreamChunk, error)
+	getPrimaryKeysFunc  func(ctx context.Context, catalog *string, schema *string, table string) (*arrow.Schema, <-chan flight.StreamChunk, error)
+	getSqlInfoFunc      func(ctx context.Context, info []uint32) (*arrow.Schema, <-chan flight.StreamChunk, error)
+	getXdbcTypeInfoFunc func(ctx context.Context, dataType *int32) (*arrow.Schema, <-chan flight.StreamChunk, error)
 }
 
 func (m *mockMetadataHandler) GetCatalogs(ctx context.Context) (*arrow.Schema, <-chan flight.StreamChunk, error) {
@@ -72,6 +74,14 @@ func (m *mockMetadataHandler) GetTableTypes(ctx context.Context) (*arrow.Schema,
 
 func (m *mockMetadataHandler) GetPrimaryKeys(ctx context.Context, catalog *string, schema *string, table string) (*arrow.Schema, <-chan flight.StreamChunk, error) {
 	return m.getPrimaryKeysFunc(ctx, catalog, schema, table)
+}
+
+func (m *mockMetadataHandler) GetSqlInfo(ctx context.Context, info []uint32) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	return m.getSqlInfoFunc(ctx, info)
+}
+
+func (m *mockMetadataHandler) GetXdbcTypeInfo(ctx context.Context, dataType *int32) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	return m.getXdbcTypeInfoFunc(ctx, dataType)
 }
 
 type mockTransactionHandler struct {


### PR DESCRIPTION
## Summary
- extend mockMetadataHandler with GetSqlInfo and GetXdbcTypeInfo
- add fuzz test exercising server methods with random data

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd8ee058832ea5e6e893c9521d56